### PR TITLE
Hide the blank space caused by appMenu

### DIFF
--- a/src/extension.js
+++ b/src/extension.js
@@ -135,6 +135,10 @@ class DesktopLyric {
 
     set index(index) {
         if(this._index === index) return;
+        if(!index) Main.panel.statusArea.appMenu.connectObject('changed', () => {
+                Main.panel.statusArea.appMenu._visible ? Main.panel.statusArea.appMenu.show() : Main.panel.statusArea.appMenu.hide();
+            }, this);
+        else Main.panel.statusArea.appMenu.disconnectObject(this);
         this._index = index;
         this.systray = false;
         this.systray = true;
@@ -240,6 +244,7 @@ class DesktopLyric {
         this._field.detach(this);
         this.systray = this.playing = null;
         Main.overview.disconnectObject(this);
+        if(!this._index) Main.panel.statusArea.appMenu.disconnectObject(this);
         ['_mpris', '_lyric', '_paper'].forEach(x => { this[x]?.destroy(); this[x] = null; });
     }
 }

--- a/src/extension.js
+++ b/src/extension.js
@@ -135,13 +135,10 @@ class DesktopLyric {
 
     set index(index) {
         if(this._index === index) return;
-        if(!index) Main.panel.statusArea.appMenu.connectObject('changed', () => {
-                Main.panel.statusArea.appMenu._visible ? Main.panel.statusArea.appMenu.show() : Main.panel.statusArea.appMenu.hide();
-            }, this);
-        else Main.panel.statusArea.appMenu.disconnectObject(this);
         this._index = index;
         this.systray = false;
         this.systray = true;
+        this.appMenuHidden = !index & this._showing;
     }
 
     set view(view) {
@@ -169,6 +166,16 @@ class DesktopLyric {
         this._showing = !closed;
         if(closed) this.status = 'Stopped';
         if(this._button) this._button.visible = !closed;
+        this.appMenuHidden = !this._index & !closed;
+    }
+
+    set appMenuHidden(appMenuHidden) {
+        if(this._appMenuHidden === appMenuHidden) return;
+        this._appMenuHidden = appMenuHidden;
+        if(appMenuHidden) Main.panel.statusArea.appMenu.connectObject('changed', () => {
+                Main.panel.statusArea.appMenu._visible ? Main.panel.statusArea.appMenu.show() : Main.panel.statusArea.appMenu.hide();
+            }, this);
+        else Main.panel.statusArea.appMenu.disconnectObject(this);
     }
 
     syncPosition(cb) {
@@ -244,7 +251,7 @@ class DesktopLyric {
         this._field.detach(this);
         this.systray = this.playing = null;
         Main.overview.disconnectObject(this);
-        if(!this._index) Main.panel.statusArea.appMenu.disconnectObject(this);
+        this.appMenuHidden = false;
         ['_mpris', '_lyric', '_paper'].forEach(x => { this[x]?.destroy(); this[x] = null; });
     }
 }


### PR DESCRIPTION
When the focused window is not showing on the screen (e.g. by entering the overview or switch to a blank workspace), the opacity of appMenu button is set to 0 but the button itself is still occupying the space. Therefore, when systray position is set to "Left", there will always be a leading space before the systray button. This PR fixes the visual issue described above.


(Just wanted to redo my messy fork which shows the lyrics on the panel, only to find that you have already added the exact same feature. Highly appreciated!! Love you<3)