### PR TITLE
Fix privacy leaks and optimize player switching

### DIFF
--- a/res/schema/schemas.gschema.xml.in
+++ b/res/schema/schemas.gschema.xml.in
@@ -10,7 +10,7 @@
         <summary>make lyric draggable or not</summary>
     </key>
     <key type="b" name="online-lyrics">
-        <default>true</default>
+        <default>false</default>
         <summary>auto download missing lyrics</summary>
     </key>
     <key type="u" name="online-provider">
@@ -57,10 +57,7 @@
         <default>(200, 200)</default>
         <summary>desktop lyric place</summary>
     </key>
-    <key type="b" name="allow-video-players">
-        <default>true</default>
-        <summary>allow video players with MPRIS support</summary>
-    </key>
+
     <key type="s" name="preferred-mpris-player">
         <default>""</default>
         <summary>preferred MPRIS player (empty for auto)</summary>

--- a/src/const.js
+++ b/src/const.js
@@ -20,7 +20,7 @@ export const Key = {
     PRVD: 'online-provider',
     SPAN: 'refresh-interval',
     ORNT: 'lyric-orientation',
-    AVPL: 'allow-video-players',
+
     PMPL: 'preferred-mpris-player',
     PWID: 'panel-width',
 };

--- a/src/extension.js
+++ b/src/extension.js
@@ -4,14 +4,14 @@
 import * as T from './util.js';
 import * as M from './menu.js';
 import * as F from './fubar.js';
-import {Key as K} from './const.js';
+import { Key as K } from './const.js';
 
 import Lyric from './lyric.js';
-import Mpris, {PlayerMenu} from './mpris.js';
+import Mpris, { PlayerMenu } from './mpris.js';
 import * as Paper from './paper.js';
 
-const {_} = F;
-const {$, $$} = T;
+const { _ } = F;
+const { $, $$ } = T;
 
 class DesktopLyric extends F.Mortal {
     constructor(gset) {
@@ -40,11 +40,11 @@ class DesktopLyric extends F.Mortal {
             ]),
             sync = F.Source.newDefer(x => x.length && this.setPosition(this.$pos = x.at(0)), // HACK: workaround for stale positions from buggy NCM mpris when changing songs
                 async n => (x => this.$pos !== x && [x])(await mpris.getPosition().catch(T.nop)) || (n > 5 && []), 500);
-        this.$src = F.Source.tie({play, paper, tray, lyric, mpris, sync}, this); // NOTE: `paper` prior `tray` to avoid double free
-        
+        this.$src = F.Source.tie({ play, paper, tray, lyric, mpris, sync }, this); // NOTE: `paper` prior `tray` to avoid double free
+
         // Create player menu manager
         this.playerMenu = new PlayerMenu(this.$src.mpris);
-        
+
         // Add dynamic menu items after mpris is initialized
         this.#updateDynamicMenuItems();
     }
@@ -63,12 +63,12 @@ class DesktopLyric extends F.Mortal {
             sep1: new M.Separator(),
             sets: new M.Item(_('Settings'), () => F.me().openPreferences()),
         }, 'lyric-symbolic', this[K.AREA] ? 0 : 5, ['left', 'center', 'right'][this[K.AREA]] ?? 'left');
-        
+
         // Set fixed width for the main tray menu to prevent expansion
         // (without modifying shared menu.js)
         tray.menu.box.set_style('width: 350px;');
-        
-        return tray[$].set({visible: this.$src?.mpris.active ?? false});
+
+        return tray[$].set({ visible: this.$src?.mpris.active ?? false });
     }
 
     #viewPaper() {
@@ -92,7 +92,7 @@ class DesktopLyric extends F.Mortal {
 
     #onAreaSet() {
         let wasActive = this.$src.mpris.active;
-        if(this[K.MINI]) {
+        if (this[K.MINI]) {
             this.setPlaying(false);
             this.$src.paper.dispel();
         }
@@ -100,11 +100,11 @@ class DesktopLyric extends F.Mortal {
         this.#updateDynamicMenuItems();
         this.#onMiniSet();
         // Restore tray visibility after recreation
-        if(wasActive) F.view(true, this.$src.tray.hub);
+        if (wasActive) F.view(true, this.$src.tray.hub);
     }
 
     #onDragSet(drag) {
-        if(this[K.MINI]) return;
+        if (this[K.MINI]) return;
         this.$src.paper.hub.setDrag(drag);
         this.$src.tray.hub.$menu.drag.setToggleState(drag);
     }
@@ -116,7 +116,7 @@ class DesktopLyric extends F.Mortal {
 
     setActive(active) {
         F.view(active, this.$src.tray.hub);
-        if(active) return;
+        if (active) return;
         this.setPlaying(false);
         this.$src.paper.hub.clearLyric();
         delete this.song;
@@ -127,7 +127,7 @@ class DesktopLyric extends F.Mortal {
     }
 
     setSong(song) {
-        if(T.homolog(this.song, song, ['title', 'album', 'lyric', 'artist'])) {
+        if (T.homolog(this.song, song, ['title', 'album', 'lyric', 'artist'])) {
             this.$src.paper.hub?.setLength(this.song.length = song.length); // HACK: workaround for jumping lengths from NCM mpris
             this.$src.sync.revive();
         } else {
@@ -137,16 +137,16 @@ class DesktopLyric extends F.Mortal {
     }
 
     loadLyric(reload) {
-        if(!this.song) return;
-        
+        if (!this.song) return;
+
         // Check if we should search for lyrics (respects manual selection)
-        if(!this.$src.mpris.shouldSearchLyrics()) {
+        if (!this.$src.mpris.shouldSearchLyrics()) {
             // For video players (not manually selected), don't search for lyrics, just show title
             this.setLyric('');
             return;
         }
-        
-        if(this.song.lyric === null) {
+
+        if (this.song.lyric === null) {
             this.setLyric('');
             this.$src.lyric.load(this.song, reload).then(x => this.setLyric(x)).catch(T.nop);
         } else {
@@ -155,13 +155,13 @@ class DesktopLyric extends F.Mortal {
     }
 
     setLyric(lyrics) {
-        if(!this.$src.paper.active) return;
-        
+        if (!this.$src.paper.active) return;
+
         // Determine if we should show song title
         // Mini mode: always show title
         // Desktop mode: never show title (only show lyrics)
         const songTitle = this[K.MINI] ? Lyric.name(this.song, ' - ', '/') : '';
-        
+
         this.$src.paper.hub[$].song(songTitle)[$]
             .setLength(this.song.length)[$]
             .setLyrics(lyrics);

--- a/src/mpris.js
+++ b/src/mpris.js
@@ -11,7 +11,7 @@ import * as PopupMenu from 'resource:///org/gnome/shell/ui/popupMenu.js';
 
 import * as T from './util.js';
 import * as F from './fubar.js';
-import {Key as K} from './const.js';
+import { Key as K } from './const.js';
 
 const MPRIS_IFACE = FileUtils.loadInterfaceXML('org.mpris.MediaPlayer2');
 const PLAYER_IFACE = FileUtils.loadInterfaceXML('org.mpris.MediaPlayer2.Player');
@@ -29,34 +29,33 @@ export default class Mpris extends F.Mortal {
         this.selector = new PlayerSelector();
         this.isRescanning = false;
         this.manuallySelected = false;
-        
+
         this.buildSources(FileUtils.loadInterfaceXML('org.gnome.Shell.Extensions.DesktopLyric.MprisPlayer'));
-        
+
         // Listen for setting changes - use F.connect for automatic cleanup on destroy
-        F.connect(this, this.$set.hub, `changed::${K.AVPL}`, () => this.onSettingChanged());
         F.connect(this, this.$set.hub, `changed::${K.PMPL}`, () => this.onPreferredPlayerChanged());
     }
 
     buildSources(playerIface) {
-        let dbus = new F.DBusProxy('org.freedesktop.DBus', '/org/freedesktop/DBus', 
-            x => x && this.rescanAndSelectPlayer(), 
+        let dbus = new F.DBusProxy('org.freedesktop.DBus', '/org/freedesktop/DBus',
+            x => x && this.rescanAndSelectPlayer(),
             null,
-            [['NameOwnerChanged', (_p, _s, [name, oldOwner, newOwner]) => { 
+            [['NameOwnerChanged', (_p, _s, [name, oldOwner, newOwner]) => {
                 // Handle both disappearance and appearance independently
                 // Reference: https://github.com/GNOME/gnome-shell/blob/9d904a804e73c97a1ecde406f395cd77a53f10e7/js/ui/mpris.js#L238
                 if (oldOwner) this.onPlayerDisappeared(name);
                 if (newOwner) this.onNewPlayer(name);
             }]]),
-            mpris = new F.Source(x => new F.DBusProxy(x, '/org/mpris/MediaPlayer2', 
+            mpris = new F.Source(x => new F.DBusProxy(x, '/org/mpris/MediaPlayer2',
                 y => y && this.$src.player.revive(y.gName),
-                [['notify::g-name-owner', (...xs) => this.onMprisChange(...xs)]], 
+                [['notify::g-name-owner', (...xs) => this.onMprisChange(...xs)]],
                 null, MPRIS_IFACE)),
-            player = new F.Source(x => new F.DBusProxy(x, '/org/mpris/MediaPlayer2', 
-                (...xs) => this.onPlayerReady(...xs), 
-                [['g-properties-changed', (...xs) => this.onPlayerChange(...xs)]], 
-                [['Seeked', (_p, _s, [pos]) => this.emit('seeked', pos / 1000)]], 
+            player = new F.Source(x => new F.DBusProxy(x, '/org/mpris/MediaPlayer2',
+                (...xs) => this.onPlayerReady(...xs),
+                [['g-properties-changed', (...xs) => this.onPlayerChange(...xs)]],
+                [['Seeked', (_p, _s, [pos]) => this.emit('seeked', pos / 1000)]],
                 playerIface));
-        this.$src = F.Source.tie({dbus, mpris, player}, this);
+        this.$src = F.Source.tie({ dbus, mpris, player }, this);
     }
 
     activate(active) {
@@ -66,14 +65,14 @@ export default class Mpris extends F.Mortal {
     rescanAndSelectPlayer() {
         if (this.isRescanning) return;
         this.isRescanning = true;
-        
+
         const wasActive = this.active;
         const currentPlayer = this.$src.mpris.hub?.gName;
-        
+
         // Clean up old player proxies
         this.scanner.cleanup();
         this.availablePlayers.clear();
-        
+
         // Re-scan all D-Bus names
         try {
             this.$src.dbus.ListNamesAsync(([xs]) => {
@@ -97,10 +96,8 @@ export default class Mpris extends F.Mortal {
     handlePlayersAvailable(currentPlayer) {
         const currentPlayerExists = currentPlayer && this.availablePlayers.has(currentPlayer);
         const preferred = this.getPreferredPlayer();
-        
-        if (!currentPlayerExists) {
-            this.selectAndActivatePlayer();
-        } else if (!preferred && this.selector.shouldAutoSwitch(currentPlayer, this.availablePlayers)) {
+
+        if (!currentPlayerExists || (!preferred && this.selector.shouldAutoSwitch(currentPlayer, this.availablePlayers))) {
             this.selectAndActivatePlayer();
         }
     }
@@ -145,11 +142,11 @@ export default class Mpris extends F.Mortal {
     selectAndActivatePlayer() {
         // Clean up invalid preferred player first
         this.cleanupInvalidPreferredPlayer();
-        
+
         const preferred = this.getPreferredPlayer();
         const currentPlayer = this.$src.mpris.hub?.gName;
         const selected = this.selector.selectPlayer(this.availablePlayers, preferred);
-        
+
         if (selected) {
             // Use revive if player already exists, summon only if it doesn't
             if (currentPlayer && this.$src.mpris.active) {
@@ -177,32 +174,31 @@ export default class Mpris extends F.Mortal {
     }
 
     getPlayerInfo(name) {
-        return this.availablePlayers.get(name) || {isVideo: false, currentTitle: null};
+        return this.availablePlayers.get(name) || { currentTitle: null };
     }
 
     async refreshPlayerTitle(name) {
-        const {title, hasLyrics} = await this.scanner.refreshPlayerMetadata(name);
+        const { title } = await this.scanner.refreshPlayerMetadata(name);
         const info = this.availablePlayers.get(name);
         if (info) {
             info.currentTitle = title;
-            info.hasLyrics = hasLyrics;
         }
     }
 
     async verifyAndRefreshPlayer(name) {
         // Verify if player is still alive and has valid media
-        const {connected, hasMedia} = await this.scanner.verifyPlayer(name);
-        
+        const { connected, hasMedia } = await this.scanner.verifyPlayer(name);
+
         if (!connected) {
             // Player is disconnected, remove it
             this.availablePlayers.delete(name);
             this.scanner.cleanupPlayer(name);
             return false;
         }
-        
+
         const info = this.availablePlayers.get(name);
         if (!info) return false;
-        
+
         if (hasMedia) {
             // Player has media, refresh its title
             await this.refreshPlayerTitle(name);
@@ -215,17 +211,7 @@ export default class Mpris extends F.Mortal {
         }
     }
 
-    isCurrentPlayerVideo() {
-        const currentPlayer = this.$src.mpris.hub?.gName;
-        if (!currentPlayer) return false;
-        const info = this.availablePlayers.get(currentPlayer);
-        return info?.isVideo || false;
-    }
-
     shouldSearchLyrics() {
-        if (this.isCurrentPlayerVideo()) {
-            return this.manuallySelected;
-        }
         return true;
     }
 
@@ -247,13 +233,13 @@ export default class Mpris extends F.Mortal {
     async onNewPlayer(name) {
         try {
             await this.scanPlayer(name);
-            
+
             const preferred = this.getPreferredPlayer();
             const newPlayerInfo = this.availablePlayers.get(name);
             const currentPlayer = this.$src.mpris.hub?.gName;
-            
+
             if (this.selector.shouldActivateNewPlayer(
-                name, newPlayerInfo, currentPlayer, preferred, this.$src.mpris.active, this.availablePlayers
+                name, newPlayerInfo, preferred, this.$src.mpris.active
             )) {
                 // Use revive if player already exists, summon only if it doesn't
                 if (currentPlayer && this.$src.mpris.active) {
@@ -285,12 +271,14 @@ export default class Mpris extends F.Mortal {
         const info = this.availablePlayers.get(name);
         if (info) {
             info.playbackStatus = newStatus;
+            if (newStatus === 'Playing') {
+                info.lastPlaying = Date.now();
+            }
         }
-        
+
         const preferred = this.getPreferredPlayer();
-        if (!preferred && this.$src.mpris.active) {
+        if (!preferred) {
             // Auto mode: always re-evaluate when any player status changes
-            // This ensures we always have the best player selected
             this.selectAndActivatePlayer();
         }
     }
@@ -307,45 +295,45 @@ export default class Mpris extends F.Mortal {
         const meta = {};
         for (const prop in metadata)
             meta[prop] = metadata[prop].deepUnpack();
-        
+
         // Validate title (required)
         const title = meta['xesam:title'];
         if (!T.str(title) || !title) return;
-        
+
         // Validate artist (should be array of strings)
         let artist = meta['xesam:artist'];
         if (!Array.isArray(artist) || !artist.every(T.str)) {
             artist = [];
         }
-        
+
         // Validate album (should be string)
         const album = T.str(meta['xesam:album']) ? meta['xesam:album'] : '';
-        
+
         // Validate lyrics (should be string)
         const lyric = T.str(meta['xesam:asText']) ? meta['xesam:asText'] : null;
-        
+
         // Validate length (should be number)
         const length = (meta['mpris:length'] || 0) / 1000;
-        
+
         this.emit('update', {
             artist: artist.flatMap(x => x.split('/')).filter(T.id),
-            length, 
-            album, 
-            lyric, 
+            length,
+            album,
+            lyric,
             title,
         });
     }
 
     async getPosition() {
         let pos = await Gio.DBus.session.call(
-            this.$src.mpris.hub.gName, 
-            '/org/mpris/MediaPlayer2', 
+            this.$src.mpris.hub.gName,
+            '/org/mpris/MediaPlayer2',
             'org.freedesktop.DBus.Properties',
-            'Get', 
-            T.pickle(['org.mpris.MediaPlayer2.Player', 'Position']), 
-            null, 
-            Gio.DBusCallFlags.NONE, 
-            -1, 
+            'Get',
+            T.pickle(['org.mpris.MediaPlayer2.Player', 'Position']),
+            null,
+            Gio.DBusCallFlags.NONE,
+            -1,
             null
         );
         return pos.recursiveUnpack().at(0) / 1000;
@@ -368,44 +356,21 @@ export function formatPlayerName(name, appInfo = null) {
         const displayName = appInfo.get_name();
         if (displayName) return displayName;
     }
-    
+
     // Fallback: Extract the app name after org.mpris.MediaPlayer2.
     // Handle reverse domain names (e.g., io.bassi.Amberol, com.github.neithern.g4music)
     const prefix = 'org.mpris.MediaPlayer2.';
     if (!name.startsWith(prefix)) return name;
-    
+
     // Remove prefix and instance suffix (e.g., .instance123)
     let appPart = name.slice(prefix.length).replace(/\.instance\d+$/, '');
-    
+
     // If it looks like a reverse domain name (contains dots), use the last segment
     const segments = appPart.split('.');
     return segments[segments.length - 1];
 }
 
-/**
- * Check if the app categories indicate a video player
- * Only checks Categories, not app names (more reliable)
- * @param {string[]|null} categories - App categories
- * @returns {boolean} - True if it's a video player
- */
-export function isVideoPlayer(categories) {
-    if (!categories) {
-        return false;
-    }
-    
-    // Video or WebBrowser category indicates video player
-    if (categories.includes('Video') || categories.includes('WebBrowser')) {
-        return true;
-    }
-    
-    // Audio or AudioVideo category indicates music player (e.g., SPlayer, yesplaymusic)
-    if (categories.includes('Audio') || categories.includes('AudioVideo')) {
-        return false;
-    }
-    
-    // Default: not a video player
-    return false;
-}
+
 
 /**
  * Parse playback status priority for auto-selection
@@ -428,7 +393,7 @@ export class PlayerScanner {
     constructor(mprisManager) {
         this.$set = mprisManager.$set;
         this.playerProxies = new Map();
-        
+
         // Auto cleanup when mpris is destroyed
         mprisManager.connect('destroy', () => this.cleanup());
     }
@@ -444,15 +409,15 @@ export class PlayerScanner {
         if (!name.startsWith('org.mpris.MediaPlayer2.')) {
             throw Error('non mpris');
         }
-        
+
         // Get player metadata
-        const {DesktopEntry, Identity} = await Gio.DBusProxy.makeProxyWrapper(MPRIS_IFACE)
+        const { DesktopEntry, Identity } = await Gio.DBusProxy.makeProxyWrapper(MPRIS_IFACE)
             .newAsync(Gio.DBus.session, name, '/org/mpris/MediaPlayer2');
-        
-        const app = DesktopEntry 
-            ? `${DesktopEntry}.desktop` 
+
+        const app = DesktopEntry
+            ? `${DesktopEntry}.desktop`
             : Identity ? Shell.AppSystem.search(Identity)[0]?.[0] : null;
-        
+
         let categories = null;
         let appInfo = null;
         if (app) {
@@ -464,77 +429,71 @@ export class PlayerScanner {
                 }
             }
         }
-        
-        // Determine if this is a video player
-        const isVideo = isVideoPlayer(categories);
-        
-        // Check if video players should be filtered out
-        const allowVideoPlayers = this.$set.hub.get_boolean(K.AVPL);
-        if (!allowVideoPlayers && isVideo) {
+
+        if (categories && (categories.includes('Video') || categories.includes('WebBrowser'))) {
             throw Error('non musical');
         }
-        
+
         // Create proxy to monitor this player's status
         let playbackStatus = 'Stopped';
         try {
             const proxy = await Gio.DBusProxy.makeProxyWrapper(PLAYER_IFACE)
                 .newAsync(Gio.DBus.session, name, '/org/mpris/MediaPlayer2');
-            
+
             playbackStatus = proxy.PlaybackStatus || 'Stopped';
-            
+
             // Monitor playback status changes
             const signalId = proxy.connect('g-properties-changed', (proxy, changed) => {
                 if (changed.lookup_value('PlaybackStatus', null)) {
                     onStatusChanged(name, proxy.PlaybackStatus);
                 }
             });
-            
+
             // Store proxy and signalId for cleanup
-            this.playerProxies.set(name, {proxy, signalId});
+            this.playerProxies.set(name, { proxy, signalId });
         } catch (e) {
             // Failed to get status, default to Stopped
         }
-        
-        // Return player info (title and lyrics will be fetched lazily when menu opens)
+
+        // Get initial metadata (title) to make auto-selection more accurate
+        const { title } = await this.refreshPlayerMetadata(name);
+
+        // Return player info
         return {
-            isVideo,
-            currentTitle: null,
+            currentTitle: title,
             playbackStatus,
-            hasLyrics: false,
+            lastPlaying: playbackStatus === 'Playing' ? Date.now() : 0,
             appInfo, // Store app info for icon
         };
     }
 
     /**
-     * Refresh the current playing title and lyrics for a player
+     * Refresh the current playing title for a player
      * @param {string} name - Player D-Bus name
-     * @returns {Promise<Object>} {title: string|null, hasLyrics: boolean}
+     * @returns {Promise<Object>} {title: string|null}
      */
     async refreshPlayerMetadata(name) {
         try {
             const proxy = await Gio.DBusProxy.makeProxyWrapper(PLAYER_IFACE)
                 .newAsync(Gio.DBus.session, name, '/org/mpris/MediaPlayer2');
-            
+
             const metadata = proxy.Metadata;
             if (metadata) {
                 // Unpack metadata following GNOME Shell's approach
                 const meta = {};
                 for (const prop in metadata)
                     meta[prop] = metadata[prop].deepUnpack();
-                
+
                 // Validate title
-                const title = (T.str(meta['xesam:title']) && meta['xesam:title'].trim()) 
+                const title = (T.str(meta['xesam:title']) && meta['xesam:title'].trim())
                     ? meta['xesam:title'] : null;
-                
-                // Check if lyrics exist
-                const hasLyrics = T.str(meta['xesam:asText']) && meta['xesam:asText'].trim().length > 0;
-                
-                return {title, hasLyrics};
+
+                return { title };
             }
         } catch (e) {
             // Ignore errors (player may have disconnected)
         }
-        return {title: null, hasLyrics: false};
+        return { title: null };
     }
 
     /**
@@ -546,33 +505,33 @@ export class PlayerScanner {
         try {
             const proxy = await Gio.DBusProxy.makeProxyWrapper(PLAYER_IFACE)
                 .newAsync(Gio.DBus.session, name, '/org/mpris/MediaPlayer2');
-            
+
             const metadata = proxy.Metadata;
             if (!metadata) {
-                return {connected: true, hasMedia: false}; // Connected but no media
+                return { connected: true, hasMedia: false }; // Connected but no media
             }
-            
+
             // Check if trackid is NoTrack (Chrome's way of saying no media)
             const trackId = metadata['mpris:trackid'];
             if (trackId && trackId.deepUnpack) {
                 const trackIdStr = trackId.deepUnpack();
                 if (trackIdStr.includes('NoTrack')) {
-                    return {connected: true, hasMedia: false}; // Connected but no active track
+                    return { connected: true, hasMedia: false }; // Connected but no active track
                 }
             }
-            
+
             // Check if title exists and is non-empty
             const title = metadata['xesam:title'];
             if (title && title.get_type_string && title.get_type_string() === 's') {
                 const unpacked = title.deepUnpack();
                 if (typeof unpacked === 'string' && unpacked.trim()) {
-                    return {connected: true, hasMedia: true}; // Has valid media
+                    return { connected: true, hasMedia: true }; // Has valid media
                 }
             }
-            
-            return {connected: true, hasMedia: false}; // Connected but no valid media
+
+            return { connected: true, hasMedia: false }; // Connected but no valid media
         } catch (e) {
-            return {connected: false, hasMedia: false}; // Connection failed
+            return { connected: false, hasMedia: false }; // Connection failed
         }
     }
 
@@ -580,7 +539,7 @@ export class PlayerScanner {
      * Clean up all player proxies
      */
     cleanup() {
-        for (const [name, {proxy, signalId}] of this.playerProxies.entries()) {
+        for (const [name, { proxy, signalId }] of this.playerProxies.entries()) {
             if (signalId) {
                 proxy.disconnect(signalId);
             }
@@ -615,17 +574,17 @@ export class PlayerSelector {
      */
     selectPlayer(availablePlayers, preferredPlayer) {
         const hasPlayers = availablePlayers.size > 0;
-        
+
         // If user explicitly selected a player
         if (preferredPlayer && availablePlayers.has(preferredPlayer)) {
             return preferredPlayer;
         }
-        
+
         // Auto mode: smart selection based on playback status
         if (!preferredPlayer && hasPlayers) {
             return this.autoSelectPlayer(availablePlayers);
         }
-        
+
         return null;
     }
 
@@ -637,60 +596,39 @@ export class PlayerSelector {
      */
     autoSelectPlayer(availablePlayers) {
         const players = Array.from(availablePlayers.entries());
-        
-        // Separate music and video players
-        const musicPlayers = players.filter(([_, info]) => !info.isVideo);
-        const videoPlayers = players.filter(([_, info]) => info.isVideo);
-        
-        // Find best of each type
-        const bestMusic = this._findBestPlayer(musicPlayers);
-        const bestVideo = this._findBestPlayer(videoPlayers);
-        
-        // No players at all
-        if (!bestMusic && !bestVideo) return null;
-        
-        // Only one type available
-        if (!bestMusic) return bestVideo;
-        if (!bestVideo) return bestMusic;
-        
-        // Both available: compare priorities with music boost
-        // Music boost: 0.5 ensures Music Playing > Video Playing > Music Paused
-        const musicInfo = availablePlayers.get(bestMusic);
-        const videoInfo = availablePlayers.get(bestVideo);
-        const musicPriority = getPlaybackPriority(musicInfo.playbackStatus) + 0.5;
-        const videoPriority = getPlaybackPriority(videoInfo.playbackStatus);
-        
-        return musicPriority >= videoPriority ? bestMusic : bestVideo;
+        return this._findBestPlayer(players);
     }
 
     /**
-     * Find best player from a list based on playback status and lyrics
-     * Priority: has lyrics > playback status
+     * Find best player from a list based on playback status
+     * Priority: playback status > latest playback
      * @param {Array} players - Array of [name, info] tuples
      * @returns {string|null} Best player name
      */
     _findBestPlayer(players) {
         if (players.length === 0) return null;
-        
+
         let bestPlayer = null;
         let bestPriority = 0;
-        
+        let bestInfo = null;
+
         for (const [name, info] of players) {
             // Base priority from playback status (Playing=3, Paused=2, Stopped=1)
             let priority = getPlaybackPriority(info.playbackStatus);
-            
-            // Boost priority if player has lyrics
-            // Add 0.3 so: Playing+Lyrics > Playing > Paused+Lyrics > Paused
-            if (info.hasLyrics) {
-                priority += 0.3;
-            }
-            
+
             if (priority > bestPriority) {
                 bestPriority = priority;
                 bestPlayer = name;
+                bestInfo = info;
+            } else if (priority === bestPriority && priority >= 1) {
+                // Tie-breaker: prefer the one that started playing more recently
+                if (info.lastPlaying > (bestInfo?.lastPlaying || 0)) {
+                    bestPlayer = name;
+                    bestInfo = info;
+                }
             }
         }
-        
+
         // If no player with priority > 0, return first player
         return bestPlayer || players[0][0];
     }
@@ -702,16 +640,8 @@ export class PlayerSelector {
      * @returns {boolean} True if should switch
      */
     shouldAutoSwitch(currentPlayer, availablePlayers) {
-        const currentInfo = availablePlayers.get(currentPlayer);
-        
-        // If current player is playing, don't switch
-        if (currentInfo?.playbackStatus === 'Playing') {
-            return false;
-        }
-        
-        // Check if any other player is playing
-        return Array.from(availablePlayers.entries())
-            .some(([name, info]) => name !== currentPlayer && info.playbackStatus === 'Playing');
+        const selected = this.autoSelectPlayer(availablePlayers);
+        return selected !== currentPlayer;
     }
 
     /**
@@ -724,41 +654,23 @@ export class PlayerSelector {
      * @param {Map<string, Object>} availablePlayers - All available players
      * @returns {boolean} True if should activate immediately
      */
-    shouldActivateNewPlayer(newPlayerName, newPlayerInfo, currentPlayer, preferredPlayer, hasActivePlayer, availablePlayers) {
+    shouldActivateNewPlayer(newPlayerName, newPlayerInfo, preferredPlayer, hasActivePlayer) {
         // No active player, activate this one
         if (!hasActivePlayer) {
             return true;
         }
-        
+
         // This is the preferred player, activate it
         if (preferredPlayer && newPlayerName === preferredPlayer) {
             return true;
         }
-        
-        // Auto mode: activate if new player is better than current
-        if (!preferredPlayer && newPlayerInfo?.playbackStatus === 'Playing') {
-            // If new player is music, always activate (music > video)
-            if (!newPlayerInfo.isVideo) {
-                return true;
-            }
-            
-            // If new player is video, only activate if current is not music
-            if (currentPlayer) {
-                const currentInfo = availablePlayers?.get(currentPlayer);
-                // Don't switch to video if current is music
-                if (currentInfo && !currentInfo.isVideo) {
-                    return false;
-                }
-            }
-            
-            return true;
-        }
-        
-        return false;
+
+        // Auto mode: activate if new player is playing
+        return !preferredPlayer && newPlayerInfo?.playbackStatus === 'Playing';
     }
 }
 
-const {_} = F;
+const { _ } = F;
 
 /**
  * PlayerMenu - Manages the MPRIS player selection submenu
@@ -785,7 +697,7 @@ export class PlayerMenu {
     buildMenu() {
         const item = new PopupMenu.PopupSubMenuMenuItem(_('Media Source'));
         this._enableEllipsis(item);
-        
+
         // Add "Auto" option
         this.autoItem = new PopupMenu.PopupMenuItem(_('Auto'));
         this._enableEllipsis(this.autoItem);
@@ -794,17 +706,17 @@ export class PlayerMenu {
             this.updateMenuLabel(item);
         });
         item.menu.addMenuItem(this.autoItem);
-        
+
         // Update menu when it opens
         item.menu.connect('open-state-changed', (menu, open) => {
             if (open) {
                 this.onMenuOpened(item);
             }
         });
-        
+
         // Initial label update
         this.updateMenuLabel(item);
-        
+
         this.menuItem = item;
         return item;
     }
@@ -824,11 +736,11 @@ export class PlayerMenu {
      */
     updateMenuLabel(item) {
         const preferred = this.mpris.getPreferredPlayer();
-        
+
         // Special labels for known values
-        const label = preferred === '' ? _('Auto') : 
-                      formatPlayerName(preferred, this.mpris.getPlayerInfo(preferred)?.appInfo);
-        
+        const label = preferred === '' ? _('Auto') :
+            formatPlayerName(preferred, this.mpris.getPlayerInfo(preferred)?.appInfo);
+
         item.label.set_text(`${_('Media Source')}: ${label}`);
     }
 
@@ -839,34 +751,34 @@ export class PlayerMenu {
     async updatePlayerMenuItems(item) {
         const players = this.mpris.getAvailablePlayers();
         const preferred = this.mpris.getPreferredPlayer();
-        
+
         // Clear existing items except the first one (Auto)
         const items = item.menu._getMenuItems();
         for (let i = items.length - 1; i >= 1; i--) {
             items[i].destroy();
         }
-        
+
         // Set ornament for Auto item
         this.autoItem?.setOrnament(!preferred ? PopupMenu.Ornament.DOT : PopupMenu.Ornament.NO_DOT);
-        
+
         // Verify and refresh all player titles, filter out dead players
         const verificationResults = await Promise.all(
             players.map(name => this.mpris.verifyAndRefreshPlayer(name))
         );
-        
+
         // Filter out players that failed verification
         const validPlayers = players.filter((name, index) => verificationResults[index]);
-        
+
         // Now add player items with updated titles
         validPlayers.forEach((name) => {
             const info = this.mpris.getPlayerInfo(name);
-            
+
             // Get display text (only title, no app name or badges)
             const displayText = info.currentTitle || formatPlayerName(name, info?.appInfo);
-            
+
             // Create menu item (ornament will be on left by default)
             const playerItem = new PopupMenu.PopupMenuItem(displayText);
-            
+
             // Add app icon before the label (after ornament)
             const icon = info.appInfo ? info.appInfo.get_icon() : null;
             if (icon) {
@@ -877,10 +789,10 @@ export class PlayerMenu {
                 // Insert icon before label
                 playerItem.insert_child_at_index(iconWidget, 1);
             }
-            
+
             // Enable ellipsis for long titles
             this._enableEllipsis(playerItem);
-            
+
             playerItem.connect('activate', () => {
                 // Toggle: if clicking already selected player, switch back to Auto
                 if (name === preferred) {
@@ -890,7 +802,7 @@ export class PlayerMenu {
                 }
                 this.updateMenuLabel(item);
             });
-            
+
             playerItem.setOrnament(name === preferred ? PopupMenu.Ornament.DOT : PopupMenu.Ornament.NO_DOT);
             item.menu.addMenuItem(playerItem);
         });

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -3,9 +3,9 @@
 
 import * as UI from './ui.js';
 import * as T from './util.js';
-import {Key as K, URL} from './const.js';
+import { Key as K, URL } from './const.js';
 
-const {_} = UI;
+const { _ } = UI;
 
 class DesktopLyricPrefs extends UI.Page {
     static {
@@ -19,13 +19,13 @@ class DesktopLyricPrefs extends UI.Page {
             [K.ONLN, new UI.Switch()],
             [K.PRGR, new UI.Switch()],
             [K.FABK, new UI.Switch()],
-            [K.AVPL, new UI.Switch()],
+
             [K.OPCT, new UI.Spin(20, 100, 5, '%')],
             [K.SPAN, new UI.Spin(20, 500, 10, _('ms'))],
             [K.PWID, new UI.Spin(100, 800, 50, _('px'))],
             [K.ORNT, new UI.Drop([_('Horizontal'), _('Vertical')])],
             [K.AREA, new UI.Drop([_('Left'), _('Center'), _('Right')])],
-            [K.PATH, new UI.File({folder: true, size: true, open: true})],
+            [K.PATH, new UI.File({ folder: true, size: true, open: true })],
             [K.PRVD, new UI.Drop([_('NetEase Cloud'), _('NetEase Cloud (Trans)'), _('LRCLIB')])],
         ];
     }
@@ -37,30 +37,30 @@ class DesktopLyricPrefs extends UI.Page {
                 [[_('_Font')], K.FONT],
                 [[_('_Opacity')], K.OPCT],
                 [[_('Or_ientation')], K.ORNT],
-            ]], 
-            
+            ]],
+
             // Behavior group
             [[[_('Behavior')]], [
                 [[_('_Mobilize'), _('Allow dragging to displace')], K.DRAG],
                 [[_('_Show progress')], K.PRGR],
                 [[_('_Refresh interval'), _('Lower values = smoother but higher CPU usage')], K.SPAN],
-            ]], 
-            
+            ]],
+
             // Player group
             [[[_('Player')]], [
                 [[_('S_ystray position')], K.AREA],
                 [[_('Panel _width'), _('Fixed width of panel lyric in pixels (minimized mode only)')], K.PWID],
-                [[_('Allow _video players'), _('Allow Chromium/Electron-based players to be recognized')], K.AVPL],
-            ]], 
-            
+
+            ]],
+
             // Lyrics Source group
             [[[_('Lyrics Source')]], [
                 [[_('_Online'), _('Try to download and save the missing lyrics')], K.ONLN],
                 [[_('_Provider'), _('Prefer <a href="%s">lyrics from Mpris metadata</a>').format('https://www.freedesktop.org/wiki/Specifications/mpris-spec/metadata/#xesam:astext')],
-                    new UI.Help(({h}) => [h(_('URL')), [
-                        [_('NetEase Cloud'), `<a href="${URL.NCM}">${URL.NCM}</a>`],
-                        [_('LRCLIB'), `<a href="${URL.LRCLIB}">${URL.LRCLIB}</a>`],
-                    ]]), K.PRVD],
+                new UI.Help(({ h }) => [h(_('URL')), [
+                    [_('NetEase Cloud'), `<a href="${URL.NCM}">${URL.NCM}</a>`],
+                    [_('LRCLIB'), `<a href="${URL.LRCLIB}">${URL.LRCLIB}</a>`],
+                ]]), K.PRVD],
                 [[_('F_allback'), _('Use the first result when searches cannot be matched precisely')], K.FABK],
                 [[_('_Location'), _('Filename format: <i>Title-Artist1,Artist2-Album.lrc</i>')], K.PATH],
             ]]


### PR DESCRIPTION
This PR addresses the privacy concerns discussed in #32 by eliminating video/browser sources and setting online lyrics to be off by default. It also optimizes the player switching logic to follow a 'latest playback wins' principle.

Key changes:
- Hard-filter video and browser categories in MPRIS scanner.
- Set `online-lyrics` to `false` by default.
- Removed 'Allow video players' setting and UI.
- Implemented timestamp-based tie-breaker in player selection for responsive switching.
- Removed metadata-based priority boosting to ensure deterministic switching.